### PR TITLE
add animation when switching between tabs

### DIFF
--- a/CookBook/app/(tabs)/index.tsx
+++ b/CookBook/app/(tabs)/index.tsx
@@ -6,6 +6,7 @@ import { Recipe } from '@/types/types'
 import { COLORS, FONT_STYLES, LAYOUT } from '@/constants/Constants'
 import { useRecipes } from '@/hooks/useRecipes'
 import { UI_LABELS } from '@/constants/Strings'
+import { AnimatedView } from '@/components/AnimatedView'
 
 export default function ListOfRecipes() {
   const [searchQuery, setSearchQuery] = useState<string>('')
@@ -42,27 +43,29 @@ export default function ListOfRecipes() {
   }
 
   return (
-    <SafeAreaView style={styles.container}>
-      <TextInput
-        style={styles.searchInput}
-        placeholder={UI_LABELS.SEARCH}
-        value={searchQuery}
-        onChangeText={setSearchQuery}
-      />
-      <FlatList
-        data={filteredRecipes}
-        keyExtractor={item => item.idMeal}
-        renderItem={({ item }) => <RecipesItem item={item} />}
-        refreshControl={
-          <RefreshControl
-            refreshing={refreshing}
-            onRefresh={onRefresh}
-            colors={[COLORS.GREY]}
-            progressBackgroundColor={COLORS.BLACK}
-          />
-        }
-      />
-    </SafeAreaView>
+    <AnimatedView>
+      <SafeAreaView style={styles.container}>
+        <TextInput
+          style={styles.searchInput}
+          placeholder={UI_LABELS.SEARCH}
+          value={searchQuery}
+          onChangeText={setSearchQuery}
+        />
+        <FlatList
+          data={filteredRecipes}
+          keyExtractor={item => item.idMeal}
+          renderItem={({ item }) => <RecipesItem item={item} />}
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={onRefresh}
+              colors={[COLORS.GREY]}
+              progressBackgroundColor={COLORS.BLACK}
+            />
+          }
+        />
+      </SafeAreaView>
+    </AnimatedView>
   )
 }
 const styles = StyleSheet.create({

--- a/CookBook/app/(tabs)/profile.tsx
+++ b/CookBook/app/(tabs)/profile.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'expo-router'
 import { useAuthStore } from '@/store/store'
 import { LanguageSwitcher } from '@/components/LanguageSwitcher'
 import { useTranslation } from 'react-i18next'
+import { AnimatedView } from '@/components/AnimatedView'
 
 export default function Profile() {
   const { isLoggedIn, logout } = useAuthStore()
@@ -22,13 +23,15 @@ export default function Profile() {
   }
 
   return (
-    <View style={styles.container}>
-      <View style={styles.languageContainer}>
-        <LanguageSwitcher />
+    <AnimatedView>
+      <View style={styles.container}>
+        <View style={styles.languageContainer}>
+          <LanguageSwitcher />
+        </View>
+        <Text style={styles.loadingText}>{t('profile.loading')}</Text>
+        <ButtonQuit onPress={handleLogout} />
       </View>
-      <Text style={styles.loadingText}>{t('profile.loading')}</Text>
-      <ButtonQuit onPress={handleLogout} />
-    </View>
+    </AnimatedView>
   )
 }
 const styles = StyleSheet.create({

--- a/CookBook/components/AnimatedView.tsx
+++ b/CookBook/components/AnimatedView.tsx
@@ -1,0 +1,24 @@
+import React, { useCallback } from 'react'
+import Animated, { useSharedValue, withTiming, useAnimatedStyle } from 'react-native-reanimated'
+import { useFocusEffect } from '@react-navigation/native'
+type AnimatedProps = {
+  children: React.ReactNode
+}
+
+export const AnimatedView = ({ children }: AnimatedProps) => {
+  const opacity = useSharedValue(0)
+  useFocusEffect(
+    useCallback(() => {
+      opacity.value = withTiming(1, { duration: 400 })
+
+      return () => {
+        opacity.value = withTiming(0, { duration: 300 })
+      }
+    }, [])
+  )
+  const styles = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+  }))
+
+  return <Animated.View style={[{ flex: 1 }, styles]}>{children}</Animated.View>
+}


### PR DESCRIPTION
The AnimatedView wrapper is implemented, which adds a smooth animation of the appearance/disappearance of the screen when switching between tabs.
- The useFocusEffect hook from @react-navigation/native was used to track screen focus.
- The animation is implemented using react-native-reanimated, based on changing opacity through useSharedValue and withTiming.
- All screens that require animation can be wrapped in an AnimatedView for reuse.